### PR TITLE
Fix bug where sender street is not printed

### DIFF
--- a/lib/Layout.js
+++ b/lib/Layout.js
@@ -30,7 +30,7 @@ Layout.getFrontPage = function(data) {
  - sender.givenName
  - sender.familyName
  - sender.company
- - sender.address  <-- /!\
+ - sender.street
  - sender.postCode
  - sender.place
 */

--- a/lib/template/back.svg.template
+++ b/lib/template/back.svg.template
@@ -39,7 +39,7 @@
 
     <text id="senderField-company"><%= sender.company %></text>
     <text id="senderField-name"><%= sender.givenName %> <%= sender.familyName %></text>
-    <text id="senderField-address"><%= sender.address %></text>
+    <text id="senderField-address"><%= sender.street %></text>
     <text id="senderField-zipAndPlace"><%= sender.postCode %> <%= sender.place %></text>
     <text id="senderField-country"></text>
   </defs>


### PR DESCRIPTION
If a postcard is created with a custom sender, the street is currently not printed on the postcard. This is because the sender object is initialized with a `street` property, whereas the template expects an `address` property.

Fixing this bug by using `street` in the template should be safe for both default and custom sender objects.
